### PR TITLE
Black Duck: Upgrade Newtonsoft.Json to version 13.0.1 fix known security vulerabilities

### DIFF
--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.Build.Download" />

--- a/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core-net6.csproj
+++ b/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core-net6.csproj
@@ -39,7 +39,7 @@
     <EmbeddedResource Include="coffee.png" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <EmbeddedResource Include="Fonts\CuteFont-Regular.ttf">
       <SubType></SubType>

--- a/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
+++ b/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdvancedColorPicker" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.22.1" />

--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.UITest" Version="3.0.15" />

--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<PackageReference Include="Newtonsoft.Json" Version="13.0.1"
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.UITest" Version="3.0.15" />


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade Newtonsoft.Json from version 12.0.3 to 13.0.1 in order to fix security vulnerabilities:

The direct dependency Newtonsoft.Json/12.0.3 has 1 vulnerabilities (max score 6.7).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Direct Dep Changed |
| --- | --- | --- | --- | --- | --- | --- |
| -/- | Newtonsoft.Json/12.0.3 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-5195/overview" target="_blank">BDSA-2018-5195</a> | 6.7 | Vulnerabilities | Newtonsoft.Json is vulnerable to denial-of-service (DoS) due to a stack overflow that can occur whenever nested objects are being processed. A remote attacker could cause a vulnerable application  ... | No |
